### PR TITLE
Add trick for stab operator lambdas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ If you know some other ruby-trick, please contribute!
 
 ### [Single instance running](single_instance_running.rb)
 
+### [Stab Operator Lambdas](stab_operator.rb)
+
 ### [Struct without assignment](struct_without_assignment.rb)
 
 ### [Super Magic keyword](super_magic_key_word.rb)

--- a/stab_operator.rb
+++ b/stab_operator.rb
@@ -1,0 +1,32 @@
+# Stab Operator - Lambdas in Ruby 1.9 or later.
+# Y Combinator
+# Ruby supports a syntax for lambdas known as the 'stab' operator.
+# Rather than something like lambda { a < 5 },
+# you can type -> { a < 5 }.
+#
+# Below is a version of the fibonacci sequence that can
+# perform recursive calls without named functions.
+#
+# Improver function for fibonacci sequence
+# Assumes that the 0th element of the sequence is 0,
+# and the 1st element of the sequence is 1.
+fib_improver = ->(partial) {
+  ->(n) { n < 2 ? n : partial.(n-1) + partial.(n-2) }
+}
+
+# The y combinator
+y = ->(f) {
+  ->(x) { x.(x) }.(
+    ->(x) { f.(->(v) { x.(x).(v)}) }
+  )
+}
+
+# Using the stab operator and y combinator, we can
+# write a fibonacci function with anonymous functions
+# This solution is not memoized and so will be very slow.
+fib = fib_improver.(y.(fib_improver))
+
+p fib.(1)
+
+p fib.(10)
+# Notice that after loading, fib isn't defined anymore.


### PR DESCRIPTION
The 'stab' operator is an alternate lambda syntax supported in Ruby 1.9 and later.

The example implements a Fibonacci function with all lambdas using the Y combinator.