### PR TITLE
Add rassoc example to associative_arrays.rb

### DIFF
--- a/associative_arrays.rb
+++ b/associative_arrays.rb
@@ -7,3 +7,10 @@ p aa.assoc("Bla")
 # Result:
 # ["Someone", "1"]
 # ["Bla", "2"]
+
+p aa.rassoc("1")
+p aa.rassoc("2")
+
+# Result:
+# ["Someone", "1"]
+# ["Bla", "2"]


### PR DESCRIPTION
I think the addition of `rassoc` usage adds value to the associative_arrays example.