### PR TITLE
Adds add_contributor rake task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *.lock
 *.pstore
-
+.DS_Store
 .idea

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,3 +15,4 @@
 - [@ezekg](https://github.com/ezekg)
 - [@0x0dea](https://github.com/0x0dea)
 - [@SkylerRogers](https://github.com/SkylerRogers)
+- [@jadercorrea](https://github.com/jadercorrea)

--- a/README.md
+++ b/README.md
@@ -1100,6 +1100,7 @@ end
 - [@ezekg](https://github.com/ezekg)
 - [@0x0dea](https://github.com/0x0dea)
 - [@SkylerRogers](https://github.com/SkylerRogers)
+- [@jadercorrea](https://github.com/jadercorrea)
 
 ## Contributing
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require './lib/contributor'
+
 desc "Build README.md from source files"
 task :build do
   toc    = []
@@ -67,4 +69,14 @@ If you know some other tricks, please contribute!
 1. Create new Pull Request and explain why your code is trick
 }
   end
+end
+
+desc 'Adds the given name a contributor'
+task :add_contributor do |t, args|
+  contributor = ARGV[1]
+  raise ArgumentError, 'Contributor name is required' if contributor.nil?
+  Contributor.new(contributor).add
+  Rake::Task['build'].execute
+  puts "#{contributor} was added as a contributor"
+  exit
 end

--- a/lib/contributor.rb
+++ b/lib/contributor.rb
@@ -1,0 +1,11 @@
+class Contributor
+  def initialize(contributor)
+    @contributor = contributor
+  end
+
+  def add
+    File.open('CONTRIBUTORS.md', 'a+') do |f|
+      f.puts "- [@#{@contributor}](https://github.com/#{@contributor})"
+    end
+  end
+end

--- a/spec/contributor_spec.rb
+++ b/spec/contributor_spec.rb
@@ -1,0 +1,19 @@
+require "./lib/contributor"
+
+describe Contributor do
+  let!(:contributor) { 'luke' }
+  let!(:original_markdown) { File.open('CONTRIBUTORS.md', 'r').read }
+
+  after do
+    File.write('CONTRIBUTORS.md', original_markdown)
+  end
+
+  subject { described_class.new(contributor) }
+
+  describe "#add" do
+    it "adds a contributor" do
+      subject.add
+      expect(File.open('CONTRIBUTORS.md', 'r').read).to match '@luke'
+    end
+  end
+end


### PR DESCRIPTION
To add a contributor, simple run rake add_contributor github_username.
It will automatically update CONTRIBUTORS and README files.