### PR TITLE
Correct wrong name for an argument

### DIFF
--- a/splat_operator.rb
+++ b/splat_operator.rb
@@ -37,4 +37,4 @@ my_method(third: 3, **arguments)
 
 # Are equivalent to:
 
-my_method(first:1, second:2, three:3)
+my_method(first:1, second:2, third:3)


### PR DESCRIPTION
I have simply correct a little error with the argument name.

